### PR TITLE
[bug] Search for the match of both: _username_ and _email_

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -161,7 +161,10 @@ module.exports = function(UserIdentity) {
 
         var query;
         if (userObj.email && userObj.username) {
-          query = {or: [
+          // If we have the email and username (Firstname and Lastname) of the user
+          // we search for that unique match of username and email
+          // Username in this case, doesn't have to be unique, because is the Firstname and Lastname of the user
+          query = {and: [
             {username: userObj.username},
             {email: userObj.email},
           ]};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "security"
   ],
   "homepage": "https://github.com/cultura-colectiva/loopback-component-passport",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "maintainers": [
     {
       "name": "Daniel Ortega",


### PR DESCRIPTION
# Issue
When two users get an invite to the CMS and both have the same name, the second in make a login to the CMS gets the info of the first.

# Solution
Modify the query to the API and get the user with _username_ and _email_ provided, not one of both.

# Long explanation
The use of the `or` in the query gets the first element in the Database Table which match; if we have the `username` and the `email`, we can query with a combination of both, to get exactly that user that we need. So we have to use the `and` in the query.