### PR TITLE
[bug] Search only by email

### DIFF
--- a/lib/models/user-identity.js
+++ b/lib/models/user-identity.js
@@ -160,19 +160,10 @@ module.exports = function(UserIdentity) {
         }
 
         var query;
-        if (userObj.email && userObj.username) {
-          // If we have the email and username (Firstname and Lastname) of the user
-          // we search for that unique match of username and email
-          // Username in this case, doesn't have to be unique, because is the Firstname and Lastname of the user
-          query = {and: [
-            {username: userObj.username},
-            {email: userObj.email},
-          ]};
-        } else if (userObj.email) {
-          query = {email: userObj.email};
-        } else {
-          query = {username: userObj.username};
-        }
+        // We have to search only by email, because maybe the user change
+        // her/his name in Facebook, and our DB is outdated.
+        // If the user has changed her/his email, is a new user for us.
+        if (userObj.email) query = {email: userObj.email};
 
         userModel.findOrCreate({where: query}, userObj, function(err, user) {
           if (user && user.status === 'inactive') return cb(new Error('This user is not active.'));


### PR DESCRIPTION
# Issue
If the user has changed the name in Facebook, the login attempts to create a new instance of the `user` model and then fails because of the uniqueness of the `email` row

# Solution
Query the API only with the email because this is the only single row in the `user` model