### PR TITLE
[feat] Send userId in the redirect URL

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -504,6 +504,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
               }
             }
             var redirect = successRedirect(req).replace(/:accessToken/, info.accessToken.id);
+            redirect = redirect.replace(/:userId/, info.accessToken.userId);
             redirect = decodeURI(redirect);
             return res.redirect(redirect);
           });


### PR DESCRIPTION
# Issue
Send the userId in the redirect URL

# Solution
Rewrite the URL with the correct parameter

# Long explanation
This is necessary to override the use of custom API endpoints to only get the userId of the current user logged in